### PR TITLE
Update xliff-conv.js

### DIFF
--- a/xliff-conv.js
+++ b/xliff-conv.js
@@ -672,7 +672,8 @@ Copyright (c) 2016, Tetsuya Mori <t2y3141592@gmail.com>. All rights reserved.
           if (op === 'default' && !transUnit.hasAttribute('approved')) {
             transUnit.setAttribute('approved', 'yes');
           }
-          if (!targetTag.hasAttribute('state')) {
+          // Fix #24: don't force the 'state' attribute if no state
+          if (!targetTag.hasAttribute('state') && state) {
             targetTag.setAttribute('state', state);
           }
           // update stats


### PR DESCRIPTION
Adds flexibility regarding the presence of the 'state' attribute to allow skipping it on the output XLIFF. For example, with a config like this:

```
var xliffConv = new XliffConv( { xliffStates: {
      'add'    : [ 'new' ],
      'replace': [ 'needs-translation', 'needs-adaptation', 'needs-l10n' ],
      'review' : [ 'needs-review-translation', 'needs-review-adaptation', 'needs-review-l10n' ],
      'translated': [ '', 'signed-off', 'final', '[state==""&&approved:="yes"]' ],
      'default': ['new', '[state=="new"&&approved:="no"]']
} } )
```

I can change the default to 'new' so that tags in JSON missing todo entries will be considered as new instead of approved, identify 'approved' entries in the XLIFF as 'translated', and finally skip adding the 'state' attribute for approved (translated) entries.
